### PR TITLE
Service name fixed

### DIFF
--- a/install-service.sh
+++ b/install-service.sh
@@ -44,11 +44,11 @@ main() {
   echo >&2
   echo 'Now, you can run
 
-  systemctl --user enable playoffs.service
+  systemctl --user enable teamster.service
 
 to enable the service after booting, and
 
-  systemctl --user start playoffs.service
+  systemctl --user start teamster.service
 
 to start it directly.
 ' >&2


### PR DESCRIPTION
The install-service.sh outputs:

```
Now, you can run

  systemctl --user enable playoffs.service

to enable the service after booting, and

  systemctl --user start playoffs.service

to start it directly.
```

However the service is called "teamster.service".